### PR TITLE
9-5-25 PR fixes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,117 +1,30 @@
 # 🏆 Goal Tracker
 
-> A reimagining of the Goal Tracker plugin — rebuilt with a more modern UI, powerful new features, and improved stability to help you plan, track, and achieve your Old School RuneScape goals with ease.  
-> It is now faster, cleaner, and more reliable — introducing a Quest Requirements system, presets, improved visuals, and smoother task/goal management.
+> A RuneLite plugin that helps you plan, track, and achieve your Old School RuneScape goals with ease.  
+> Goal Tracker provides presets, quest requirements, progress bars, and a modern UI to make managing your tasks and goals simple and efficient.
 
 ---
+## Plugin Features
 
-✨ New Features
-- Shift+Click task removal for faster management
-- Automatic goal status checks for real-time progress
-- ActionBar & ActionBarButton UI components for navigation and bulk actions
-- Progress bars added under each goal card on the Home panel for quick visual tracking
-- Quest Requirements file built and integrated for quick access to quest prerequisites
-- Preset Goal Lists
-- Export/Import goals to JSON with full UI refresh
-- Inline editing for goal titles and manual tasks
-- Long titles now ellipsized with hover-to-view full text
+- Preset Goal Lists for quick setup of common goals
+- Pin important goals to the top of the Home panel
+- Automatically add prerequisites for quests
+- Track progress with visual progress bars
+- Import and Export goals via JSON for easy sharing or backups
+- Create and manage custom goals with tasks
 
-♻️ Redesigned
-- Quest prerequisites button leveraging the new Quest Requirements file
-- Cascading completion to auto-complete related tasks
-- Dropdown quest selector for faster task addition
-- Right-click menus streamlined for prerequisites and child task options
-- Goal/task cards with lighter fills, shadows, hover/press effects, and clear header dividers
+## Screenshots
 
-🐛 Fixes
-- Undo/Redo functionality cleanup
-- ActionBarButton painting glitches resolved
-- Proper refresh handling in GoalTrackerPanel and ListPanel
-- Fixed blank/refresh issues when switching panels or logging in
-- Item icons preload correctly at startup/login/import
-- Home panel refreshes immediately after task completion
-- Layout fixes around Export button to avoid overlap
-- Recursive refresh of child tasks ensures status consistency
-
-### 🖼️ Screenshots
-
-- **Home panel with goal cards** — redesigned buttons with hover/press effects, new progress bars under each goal card, plus the “Add from Preset” button and Export/Import to JSON buttons for easy sharing.  
+- **Home panel with goal cards** — shows progress bars, presets, and export/import buttons.  
   <img src="img/home_panel_new.jpg" alt="Home panel screenshot showing goal cards" width="40%" style="border:1px solid #000; box-shadow: 2px 2px 6px rgba(0,0,0,0.3); border-radius:4px;" />
 
-- **Inside a goal with task list** — supports auto-fill quest prerequisites, right-click task options, a new item search box, and a dropdown quest selector.  
+- **Inside a goal with task list** — displays quest prerequisites, right-click task options, item search, and a quest selector.  
   <img src="img/goal_task_panel.jpg" alt="Goal task panel screenshot with tasks list" width="40%" style="border:1px solid #000; box-shadow: 2px 2px 6px rgba(0,0,0,0.3); border-radius:4px;" />
 
-- **Right‑click menu on a Home panel goal card** — manage goals quickly with options to move, pin, mark complete/incomplete, or delete.  
+- **Right‑click menu on a goal card** — options to move, pin, mark complete, or delete.  
   <img alt="Right-click menu screenshot on Home panel goal card" src="img/right_click_goals.jpg" width="50%"/>
 
-- **Add from preset** — includes built-in support for Barrows gear, Void armor sets, and basic Ironman progression presets.  
+- **Add from preset** — includes built-in options for Barrows gear, Void armor, and Ironman progression.  
   <img alt="Add from preset screenshot with preset options" src="img/add_from_preset.jpg" width="60%"/>
 
 -----
-<details>
-<summary><span style="margin-left:8px;"><h3 style="display:inline;">📜 Original Goal Tracker v1 Readme & Documentation (created by dillydill123)</h3></span></summary>
-
-# Runelite Goal Tracker Plugin
-
-Keep track of your OSRS goals and complete them automatically.
-
-## Features
-
-- Track different types of tasks
-    - Manual tasks
-    - Skill tasks
-    - Quests
-    - Item tasks
-- Organise tasks lists into goals
-- Reorder and manage goal and task lists
-- Chat notification on task completion
-
-### Planned
-
-- More task types
-    - Achievement diaries
-    - Minigame rewards
-    - Kourend favour
-    - NPC kills
-
-Suggestions are welcome - please submit an issue :)
-
-## Usage
-
-### Goals
-
-Goals are lists of tasks, and at a glance provide a quick way to view your progress towards the goal.
-
-![Goals list](img/goals_list.png)
-
-You can add a new goal with the "+ Add goal" button, and you can reorder/remove goals using right click. Clicking a goal will show the tasks within:
-
-![Goal view](img/goal_view.png)
-
-From here, you can add tasks to the goal.
-
-### Adding tasks
-
-![Task inputs](img/task_inputs.png)
-
-#### Manual tasks
-
-Basically a simple to-do list item. You can add these via the "Quick add" text box.
-
-You can toggle them on and off manually just by clicking them.
-
-Use the "+ More options" button to reveal the automatic task options.
-
-#### Skill level/XP tasks
-
-Use these tasks to automatically track skill progress. Just select a skill, and the desired level or XP amount. The task will automatically complete once you hit that level/xp.
-
-#### Quest tasks
-
-Track quest progress and completion, just select a quest or miniquest from the dropdown. Will also display in progress quests as orange.
-
-#### Item tasks
-
-Select an item using the search button and searching via the in-game chatbox, then set the desired quantity. The plugin will keep track of your items and tally up quantities stored in different inventories (bank, player, GIMP storage), and will be automatically completed once you get that amount of the item.
-
-</details>

--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,7 @@ Please leave for my sanity. thanks :)
 - Manual completion toggling for preset tasks.
 - Configurable color setting for completion chat messages.
 - Export and import goals to JSON with file filtering and full UI refresh.
-- Preset Goal Lists with an “Add from Preset…” button (including Quest Cape, Ironman progressions, Void, F2P, Fast Travel, etc.).
+- Preset Goal Lists with an “Add from Preset…” button.
 - Full Void Armor, Free-to-Play Quests, and Fast Travel Unlocks presets.
 - Expanded and reworked Early, Mid, and Late Ironman presets.
 - Inline editing support for goal titles and manual task descriptions.

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@ Please leave for my sanity. thanks :)
 - Task rows updated with consistent styling, icon warming, and inline editing capabilities.
 - Home panel buttons stacked vertically; header divider thickness increased for clarity.
 - Goal card typography fixed with reserved progress text width to prevent clipping.
+- Home panel placeholder updated to use wrapping text; empty text now displays cleanly without clipping.
 
 ### Fixed
 - Fixed chat completion messages: now appear reliably as `GAMEMESSAGE`s with configured colors; raw `<col>` tags removed.

--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,9 @@ Please leave for my sanity. thanks :)
 - Home panel buttons stacked vertically; header divider thickness increased for clarity.
 - Goal card typography fixed with reserved progress text width to prevent clipping.
 - Home panel placeholder updated to use wrapping text; empty text now displays cleanly without clipping.
+- Export to file now prompts before overwriting existing files.
+- Import from file now prompts with Overwrite / Merge / Cancel options instead of silently replacing goals.
+- Home panel no longer forces alphabetical order; manual Move actions now persist with pinned-first grouping only.
 
 ### Fixed
 - Fixed chat completion messages: now appear reliably as `GAMEMESSAGE`s with configured colors; raw `<col>` tags removed.
@@ -45,3 +48,9 @@ Please leave for my sanity. thanks :)
 - Fixed empty goals remaining in list; now automatically removed if left without tasks.
 - Fixed overlapping Export button layout issue.
 - Fixed quest tasks not showing correct status on login until entering the goal.
+- Fixed card rename editor stretching beyond panel width; editor now constrained to card body.
+- Fixed inconsistent rename activation; description text is read-only unless rename explicitly invoked.
+- Added right-click Rename option with bounded editor, commit/cancel, and ESC cancel support.
+- Fixed duplicate Pin/Unpin menu items by centralizing handling in ListItemPanel.
+- Fixed unpinning a card not refreshing the Home panel immediately; Home panel now rebuilds/reorders on pin state toggle.
+- Fixed Move right-click options (Up/Down/Top/Bottom) not changing card position; moves now reorder cards properly.

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Goal Tracker
-author=toofifty
-support=https://github.com/toofifty/goaltracker
+author=Toofifty
+support=https://github.com/Toofifty/rl-goal-tracker
 description=Track and organize RuneScape goals with progress bars, presets, and more.
 tags=task,to-do,todo,Track,organize,progress
 plugins=com.toofifty.goaltracker.GoalTrackerPlugin

--- a/src/main/java/com/toofifty/goaltracker/GoalManager.java
+++ b/src/main/java/com/toofifty/goaltracker/GoalManager.java
@@ -102,14 +102,25 @@ public final class GoalManager
         return goalSerializer.serialize(goals, pretty);
     }
 
-    /**
-     * Import goals from JSON and persist them.
-     */
     public void importJson(String json)
+    {
+        // Backwards-compatible default: overwrite existing goals
+        importJson(json, true);
+    }
+
+    /**
+     * Import goals from JSON, optionally merging with existing goals.
+     * @param json the JSON payload
+     * @param overwrite if true, clears existing goals first; if false, appends imported goals
+     */
+    public void importJson(String json, boolean overwrite)
     {
         try
         {
-            this.goals.clear();
+            if (overwrite)
+            {
+                this.goals.clear();
+            }
             this.goals.addAll(goalSerializer.deserialize(json));
             save();
         }

--- a/src/main/java/com/toofifty/goaltracker/models/task/SkillLevelTask.java
+++ b/src/main/java/com/toofifty/goaltracker/models/task/SkillLevelTask.java
@@ -19,15 +19,15 @@ public final class SkillLevelTask extends Task
     private int level;
 
     @Override
-    public String toString()
-    {
-        return String.format("%s %s", level, skill.getName());
-    }
-
-    @Override
     public String getDisplayName()
     {
         return String.format("Reach level %d %s", level, skill.getName());
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s %s", level, skill.getName());
     }
 
     @Override

--- a/src/main/java/com/toofifty/goaltracker/models/task/Task.java
+++ b/src/main/java/com/toofifty/goaltracker/models/task/Task.java
@@ -61,13 +61,14 @@ public abstract class Task
         return !isFullyIndented();
     }
 
+
+    @Override
+    abstract public String toString();
+
     /**
      * Returns a human-readable name for the task.
      */
     public abstract String getDisplayName();
-
-    @Override
-    abstract public String toString();
 
     abstract public TaskType getType();
 }

--- a/src/main/java/com/toofifty/goaltracker/ui/GoalItemContent.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/GoalItemContent.java
@@ -23,7 +23,7 @@ import static com.toofifty.goaltracker.utils.Constants.STATUS_TO_COLOR;
  */
 public final class GoalItemContent extends JPanel implements Refreshable
 {
-    private final JLabel titleLabel = new JLabel();
+    private final JTextArea titleLabel = new JTextArea();
     private final JTextField titleEdit = new JTextField();
     private final JLabel progress = new JLabel();
     private final SlimBar progressBar = new SlimBar();
@@ -41,7 +41,7 @@ public final class GoalItemContent extends JPanel implements Refreshable
         super(new BorderLayout());
         this.goal = goal;
 
-        setBorder(BorderFactory.createEmptyBorder(6, 8, 6, 8)); // padding for centered text
+        setBorder(BorderFactory.createEmptyBorder(6, 0, 6, 0)); // remove extra left/right padding so title can span edge-to-edge within the card body
         // Let the parent card body paint the background; avoid double fills
         setOpaque(false);
         setBackground(null);
@@ -50,10 +50,15 @@ public final class GoalItemContent extends JPanel implements Refreshable
         topRow.setOpaque(false);
 
         // Title label (display mode)
-        titleLabel.setBorder(null);
+        titleLabel.setLineWrap(true);
+        titleLabel.setWrapStyleWord(true);
+        titleLabel.setEditable(false);
         titleLabel.setOpaque(false);
+        titleLabel.setBorder(null);
         titleLabel.setFocusable(false);
-        titleLabel.setToolTipText(null);
+        titleLabel.setFont(getFont());
+        titleLabel.setMinimumSize(new Dimension(0, titleLabel.getPreferredSize().height));
+        titleLabel.setMargin(new Insets(0, 0, 0, 0));
 
         // Title edit (edit mode)
         titleEdit.setBorder(null);
@@ -75,6 +80,8 @@ public final class GoalItemContent extends JPanel implements Refreshable
             @Override public void focusLost(java.awt.event.FocusEvent e) { exitEdit(true); }
         });
 
+        // Place progress at the far right with a small left gap and a yellow border
+        progress.setBorder(new javax.swing.border.EmptyBorder(0, 3, 0, 0));
         topRow.add(progress, BorderLayout.EAST);
 
         // Reserve fixed width for progress like 999/999 so it never clips
@@ -82,7 +89,6 @@ public final class GoalItemContent extends JPanel implements Refreshable
         Dimension progSize = new Dimension(progW, progress.getPreferredSize().height);
         progress.setPreferredSize(progSize);
         progress.setMinimumSize(progSize);
-
         add(topRow, BorderLayout.CENTER);
 
         // Slim custom progress bar under the title row
@@ -243,36 +249,8 @@ public final class GoalItemContent extends JPanel implements Refreshable
     {
         if (topRow == null) return;
         String full = goal.getDescription() != null ? goal.getDescription() : "";
+        titleLabel.setText(full.isBlank() ? " " : full);
         titleLabel.setToolTipText(full.isEmpty() ? null : full);
-
-        // Compute available width for title (row width minus progress preferred width and a small gap)
-        int rowW = topRow.getWidth();
-        if (rowW <= 0) { titleLabel.setText(full); return; }
-        int gap = 8;
-        int avail = Math.max(16, rowW - progress.getPreferredSize().width - gap);
-
-        FontMetrics fm = titleLabel.getFontMetrics(titleLabel.getFont());
-        if (fm.stringWidth(full) <= avail) {
-            titleLabel.setText(full);
-            return;
-        }
-        String ellipsis = "…";
-        String text = full;
-        // Binary-like trim from the end until it fits
-        int lo = 0, hi = full.length();
-        int cut = hi;
-        while (lo <= hi) {
-            int mid = (lo + hi) >>> 1;
-            String candidate = full.substring(0, Math.max(0, mid)) + ellipsis;
-            if (fm.stringWidth(candidate) <= avail) {
-                cut = mid;
-                lo = mid + 1;
-            } else {
-                hi = mid - 1;
-            }
-        }
-        text = full.substring(0, Math.max(0, cut)) + ellipsis;
-        titleLabel.setText(text);
     }
 
     private void enterEdit()

--- a/src/main/java/com/toofifty/goaltracker/ui/GoalPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/GoalPanel.java
@@ -69,6 +69,43 @@ public final class GoalPanel extends JPanel implements Refreshable
         actionBar.left().add(undoButton);
         actionBar.left().add(redoButton);
 
+        ActionBarButton importButton = new ActionBarButton("Import", () -> {
+            String input = javax.swing.JOptionPane.showInputDialog(GoalPanel.this, "Paste goals JSON:");
+            if (input == null) {
+                return; // canceled
+            }
+            input = input.trim();
+            if (input.isEmpty()) {
+                return; // nothing to import
+            }
+
+            Object[] options = {"Overwrite", "Merge", "Cancel"};
+            int choice = javax.swing.JOptionPane.showOptionDialog(
+                GoalPanel.this,
+                "Importing will change your current goals.\nDo you want to overwrite existing goals or merge with them?",
+                "Import Goals",
+                javax.swing.JOptionPane.YES_NO_CANCEL_OPTION,
+                javax.swing.JOptionPane.QUESTION_MESSAGE,
+                null,
+                options,
+                options[2]
+            );
+
+            if (choice == javax.swing.JOptionPane.YES_OPTION) {
+                plugin.getGoalManager().importJson(input, true);   // Overwrite
+            } else if (choice == javax.swing.JOptionPane.NO_OPTION) {
+                plugin.getGoalManager().importJson(input, false);  // Merge
+            } else {
+                return; // canceled
+            }
+
+            // Refresh current view after import
+            plugin.setValidateAll(true);
+            plugin.getUiStatusManager().refresh(goal);
+            refreshTaskList();
+        });
+        actionBar.left().add(importButton);
+
         // Stack back row above the action bar in the header's NORTH
         JPanel headerTop = new JPanel();
         headerTop.setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -106,7 +143,7 @@ public final class GoalPanel extends JPanel implements Refreshable
                 taskPanel.setOpaque(true);
                 taskPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
                 taskPanel.setBorder(BorderFactory.createCompoundBorder(
-                    BorderFactory.createMatteBorder(4, 6, 0, 6, ColorScheme.DARKER_GRAY_COLOR), // darker line for contrast
+                    BorderFactory.createMatteBorder(1, 6, 0, 6, ColorScheme.DARKER_GRAY_COLOR), // thinner divider
                     new EmptyBorder(2, 4, 2, 4)
                 ));
 

--- a/src/main/java/com/toofifty/goaltracker/ui/TaskItemContent.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/TaskItemContent.java
@@ -28,6 +28,8 @@ import static com.toofifty.goaltracker.utils.Constants.STATUS_TO_COLOR;
  */
 public final class TaskItemContent extends JPanel implements Refreshable
 {
+    private static final int INDENT_PER_LEVEL = 12; // pixels per indent level
+
     private final Task task;
     private final Goal goal;
     private final TaskIconService iconService;
@@ -145,9 +147,15 @@ public final class TaskItemContent extends JPanel implements Refreshable
         titleLabel.setForeground(STATUS_TO_COLOR.get(task.getStatus()));
         updateTitleLabel();
 
-        int indent = 16 * task.getIndentLevel();
+        int level = Math.max(0, task.getIndentLevel());
+        // Shift rendering so level 0 = 0px, level 1 = 0px, level 2 = 12px, etc.
+        // This avoids the first child appearing with an extra indent when prereqs are added.
+        int indent = (level <= 1) ? 0 : (level - 1) * INDENT_PER_LEVEL;
+
         iconLabel.setIcon(iconService.get(task));
-        iconLabel.setBorder(new EmptyBorder(0, indent, 0, 0));
+        // Apply indent to the wrapper instead of the label to avoid double padding
+        iconLabel.setBorder(new EmptyBorder(0, 0, 0, 0));
+        iconWrapper.setBorder(new EmptyBorder(4, indent, 0, 4));
 
         revalidate();
     }

--- a/src/main/java/com/toofifty/goaltracker/ui/components/ListItemPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/components/ListItemPanel.java
@@ -88,6 +88,7 @@ public class ListItemPanel<T> extends JPanel implements Refreshable
         // Create inner card surface to isolate hover/press background changes
         cardBody = new JPanel(new BorderLayout());
         cardBody.setOpaque(true);
+        cardBody.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
         // Add the cardBody as the main content area
         super.add(cardBody, BorderLayout.CENTER);
 
@@ -250,20 +251,14 @@ public class ListItemPanel<T> extends JPanel implements Refreshable
 
     private void applyGoalCardDefaultStyle()
     {
-        // Outer spacing + shadow on the container panel
-        setBorder(javax.swing.BorderFactory.createCompoundBorder(
-            new EmptyBorder(8, 6, 8, 6),
-            new MatteBorder(2, 2, 4, 4, new Color(0, 0, 0, 60)) // shadow on all sides
-        ));
+        // Outer spacing only (no colored line border)
+        setBorder(new EmptyBorder(8, 6, 8, 6));
         setBackground(ColorScheme.DARK_GRAY_COLOR); // keep outer area stable
 
         // Inner card face: rounded outline + inner padding
         if (cardBody != null)
         {
-            cardBody.setBorder(javax.swing.BorderFactory.createCompoundBorder(
-                javax.swing.BorderFactory.createLineBorder(ColorScheme.DARK_GRAY_COLOR, 1, true),
-                new EmptyBorder(6, 8, 6, 8)
-            ));
+            cardBody.setBorder(new EmptyBorder(4, 6, 4, 6));
             cardBody.setBackground(ColorScheme.DARK_GRAY_COLOR);
         }
     }

--- a/src/main/java/com/toofifty/goaltracker/ui/components/ListPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/components/ListPanel.java
@@ -31,6 +31,9 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
     private JComponent placeholder = new JLabel("Nothing interesting happens.");
     private Consumer<T> updatedListener;
 
+    private int rowLeftInset = 0;
+    private int rowRightInset = 0;
+
     public ListPanel(
         ReorderableList<T> reorderableList,
         Function<T, ListItemPanel<T>> renderItem
@@ -63,6 +66,13 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
     {
         this.gap = gap;
         setBorder(new EmptyBorder(0, 0, 0, 0));
+        tryBuildList();
+    }
+
+    public void setRowSideInsets(int left, int right)
+    {
+        this.rowLeftInset = Math.max(0, left);
+        this.rowRightInset = Math.max(0, right);
         tryBuildList();
     }
 
@@ -135,7 +145,7 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
         constraints.weightx = 1;
         constraints.gridy = gridy;
         constraints.gridx = 0;
-        constraints.insets = new Insets(4, -4, gap, -4);
+        constraints.insets = new Insets(4, rowLeftInset, gap, rowRightInset);
         return constraints;
     }
 
@@ -153,6 +163,8 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
      */
     public void tryBuildList()
     {
+        itemPanelMap.clear();
+
         if (reorderableList.isEmpty()) {
             listPanel.removeAll();
 

--- a/src/main/java/com/toofifty/goaltracker/ui/components/ListPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/components/ListPanel.java
@@ -28,7 +28,7 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
     private final Map<T, ListItemPanel<T>> itemPanelMap = new HashMap<>();
 
     private int gap = 2;
-    private String placeholder = "Nothing interesting happens.";
+    private JComponent placeholder = new JLabel("Nothing interesting happens.");
     private Consumer<T> updatedListener;
 
     public ListPanel(
@@ -39,15 +39,16 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
         this.reorderableList = reorderableList;
         this.renderItem = renderItem;
 
-        setBorder(new EmptyBorder(10, 10, 10, 10));
 
         listPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+        // Add left/right padding so card content aligns with the header
+        listPanel.setBorder(new EmptyBorder(0, 10, 0, 10));
 
         JPanel wrapperPanel = new JPanel(new BorderLayout());
         wrapperPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
         wrapperPanel.add(listPanel, BorderLayout.NORTH);
 
-        setBorder(new EmptyBorder(4, 4, 4 - gap, 4));
+        setBorder(new EmptyBorder(0, 0, 0, 0));
         setBackground(ColorScheme.DARKER_GRAY_COLOR);
         getVerticalScrollBar().setPreferredSize(new Dimension(12, 0));
         getVerticalScrollBar().setBorder(new EmptyBorder(0, 4, 0, 0));
@@ -61,13 +62,19 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
     public void setGap(int gap)
     {
         this.gap = gap;
-        setBorder(new EmptyBorder(4, 4, 4 - gap, 4));
+        setBorder(new EmptyBorder(0, 0, 0, 0));
         tryBuildList();
     }
 
-    public void setPlaceholder(String placeholder)
+    public void setPlaceholder(String placeholderText)
     {
-        this.placeholder = placeholder;
+        this.placeholder = new JLabel(placeholderText);
+        tryBuildList();
+    }
+
+    public void setPlaceholder(JComponent placeholderComponent)
+    {
+        this.placeholder = placeholderComponent;
         tryBuildList();
     }
 
@@ -128,7 +135,7 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
         constraints.weightx = 1;
         constraints.gridy = gridy;
         constraints.gridx = 0;
-        constraints.insets = new Insets(0, 0, gap, 0);
+        constraints.insets = new Insets(4, -4, gap, -4);
         return constraints;
     }
 
@@ -149,11 +156,13 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
         if (reorderableList.isEmpty()) {
             listPanel.removeAll();
 
-            JLabel placeholderLabel = new JLabel(placeholder);
-            placeholderLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+            if (placeholder instanceof JLabel) {
+                ((JLabel) placeholder).setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+            }
             JPanel placeholderPanel = new JPanel();
             placeholderPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
-            placeholderPanel.add(placeholderLabel);
+            placeholderPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 0, 0));
+            placeholderPanel.add(placeholder);
             listPanel.add(placeholderPanel, getConstraints());
         } else {
             listPanel.removeAll();

--- a/src/main/java/com/toofifty/goaltracker/utils/QuestRequirements.java
+++ b/src/main/java/com/toofifty/goaltracker/utils/QuestRequirements.java
@@ -215,6 +215,21 @@ public final class QuestRequirements
         );
 
         REQUIREMENT_MAP.put(
+                Quest.THE_PATH_OF_GLOUPHRIE,
+                Arrays.asList(
+                        QuestTask.builder().quest(Quest.WATERFALL_QUEST).build(),
+                        QuestTask.builder().quest(Quest.THE_EYES_OF_GLOUPHRIE).build(),
+                        QuestTask.builder().quest(Quest.TREE_GNOME_VILLAGE).build(),
+                        QuestTask.builder().quest(Quest.THE_GRAND_TREE).build(),
+                        SkillLevelTask.builder().skill(Skill.STRENGTH).level(60).build(),
+                        SkillLevelTask.builder().skill(Skill.SLAYER).level(56).build(),
+                        SkillLevelTask.builder().skill(Skill.THIEVING).level(56).build(),
+                        SkillLevelTask.builder().skill(Skill.RANGED).level(47).build(),
+                        SkillLevelTask.builder().skill(Skill.AGILITY).level(45).build()
+                )
+        );
+
+        REQUIREMENT_MAP.put(
                 Quest.THE_FEUD,
                 Arrays.asList(
                         SkillLevelTask.builder().skill(Skill.THIEVING).level(30).build()


### PR DESCRIPTION
Main fixes/changes
- Goal card typography fixed with reserved progress text width to prevent clipping.
- Home panel placeholder updated to use wrapping text; empty text now displays cleanly without clipping.
- Export to file now prompts before overwriting existing files.
- Import from file now prompts with Overwrite / Merge / Cancel options instead of silently replacing goals.
- Home panel no longer forces alphabetical order; manual Move actions now persist with pinned-first grouping only.
